### PR TITLE
Display toast if insufficient permissions to access page

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -75,7 +75,7 @@ jobs:
   deployfirebase:
     name: Deploy Firebase Project
     needs: [buildandtest, determineenvironment, vars]
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@envFirebase2
+    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
     permissions:
       contents: read
     with:

--- a/modules/firebase/app.ts
+++ b/modules/firebase/app.ts
@@ -21,6 +21,8 @@ import {
   getDocumentsRefs,
 } from '@/modules/firebase/utils'
 import { queryClient } from '@/modules/query/queryClient'
+import { toast } from '@/packages/design-system/src/components/Toaster'
+import { routes } from '@/modules/routes'
 
 const firebaseApp = initializeApp(firebaseConfig)
 
@@ -68,6 +70,7 @@ export const getCurrentUser = async () => {
 export const ensureType = async (types: UserType[]) => {
   const type = await getCurrentUserType()
   if (!types.includes(type)) {
-    throw redirect({ to: '/' })
+    toast.error(`You don't have permissions to access this page`)
+    throw redirect({ to: routes.home })
   }
 }

--- a/modules/firebase/app.ts
+++ b/modules/firebase/app.ts
@@ -21,8 +21,8 @@ import {
   getDocumentsRefs,
 } from '@/modules/firebase/utils'
 import { queryClient } from '@/modules/query/queryClient'
-import { toast } from '@/packages/design-system/src/components/Toaster'
 import { routes } from '@/modules/routes'
+import { toast } from '@/packages/design-system/src/components/Toaster'
 
 const firebaseApp = initializeApp(firebaseConfig)
 


### PR DESCRIPTION
# Display toast if insufficient permissions to access page

## :recycle: Current situation & Problem
User is redirected without any feedback. Just for UX clarify, we need users to know why redirection happened.

Closes #21 


## :gear: Release Notes 
* Display toast if insufficient permissions to access page


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
