### PR TITLE
Add email field tooltip about SSO identifier

### DIFF
--- a/routes/~_dashboard/~users/UserForm.tsx
+++ b/routes/~_dashboard/~users/UserForm.tsx
@@ -81,6 +81,7 @@ export const UserForm = ({
         control={form.control}
         name="email"
         label="Email"
+        tooltip="Email should be the unique SSO indentifier of your organization"
         render={({ field }) => <Input type="email" {...field} />}
       />
       <Field


### PR DESCRIPTION
# Add email field tooltip about SSO identifier

## :recycle: Current situation & Problem
Email field might be unclear.


## :gear: Release Notes 
* Add email field tooltip about SSO identifier

![image](https://github.com/user-attachments/assets/80f51ec7-2207-4f61-963a-e014893de824)


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
