### PR TITLE
Make invitation code readonly

### DIFF
--- a/routes/~_dashboard/~patients/PatientForm.tsx
+++ b/routes/~_dashboard/~patients/PatientForm.tsx
@@ -27,7 +27,6 @@ import { type User } from '@/modules/firebase/models'
 export const patientFormSchema = z.object({
   email: z.string().email().min(1, 'Email is required'),
   displayName: z.string(),
-  invitationCode: z.string(),
   clinician: z.string().min(1, 'Clinician is required'),
   dateOfBirth: z.date().optional(),
 })
@@ -41,10 +40,7 @@ interface PatientFormProps {
     email: string | null
   }>
   userInfo?: Pick<UserInfo, 'email' | 'displayName' | 'uid'>
-  user?: Pick<
-    User,
-    'organization' | 'invitationCode' | 'clinician' | 'dateOfBirth'
-  >
+  user?: Pick<User, 'organization' | 'clinician' | 'dateOfBirth'>
   onSubmit: (data: PatientFormSchema) => Promise<void>
   clinicianPreselectId?: string
 }
@@ -62,7 +58,6 @@ export const PatientForm = ({
     defaultValues: {
       email: userInfo?.email ?? '',
       displayName: userInfo?.displayName ?? '',
-      invitationCode: user?.invitationCode ?? '',
       clinician: user?.clinician ?? clinicianPreselectId ?? '',
       dateOfBirth: user?.dateOfBirth ? new Date(user.dateOfBirth) : undefined,
     },
@@ -100,14 +95,6 @@ export const PatientForm = ({
           />
         )}
       />
-      {isEdit && (
-        <Field
-          control={form.control}
-          name="invitationCode"
-          label="Invitation code"
-          render={({ field }) => <Input {...field} />}
-        />
-      )}
       <Field
         control={form.control}
         name="clinician"

--- a/routes/~_dashboard/~patients/utils.ts
+++ b/routes/~_dashboard/~patients/utils.ts
@@ -232,6 +232,7 @@ export const getUserActivity = async ({
   return {
     lastActiveDate: user.lastActiveDate,
     latestQuestionnaireDate: latestQuestionnaires.at(0)?.authored,
+    invitationCode: user.invitationCode,
     isInvitation: resourceType === 'invitation',
   }
 }

--- a/routes/~_dashboard/~patients/~$id/UserActivity.tsx
+++ b/routes/~_dashboard/~patients/~$id/UserActivity.tsx
@@ -6,13 +6,9 @@
 // SPDX-License-Identifier: MIT
 //
 
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-} from '@stanfordspezi/spezi-web-design-system/components/Card'
+import { Card } from '@stanfordspezi/spezi-web-design-system/components/Card'
 import { formatNilDateTime } from '@stanfordspezi/spezi-web-design-system/utils/date'
-import { Clock, FileQuestion, Mail } from 'lucide-react'
+import { Clock, FileQuestion, Mail, BookLock } from 'lucide-react'
 import { type ReactNode } from 'react'
 import { type UserActivity as UserActivityType } from '@/routes/~_dashboard/~patients/utils'
 
@@ -38,11 +34,13 @@ interface UserActivityProps {
 
 export const UserActivity = ({ activity }: UserActivityProps) => (
   <Card className="xl:min-w-max xl:self-start">
-    <CardHeader>
-      <CardTitle>User activity</CardTitle>
-    </CardHeader>
-    <div className="px-5 pb-4 marker:text-primary">
+    <div className="px-5 py-4 marker:text-primary">
       <ul className="flex list-disc flex-col gap-4">
+        <ActivityRow
+          icon={<BookLock className="size-5" />}
+          label="Invitation code"
+          value={activity.invitationCode}
+        />
         {activity.isInvitation && (
           <ActivityRow
             icon={<Mail className="size-5" />}

--- a/routes/~_dashboard/~patients/~$id/~index.tsx
+++ b/routes/~_dashboard/~patients/~$id/~index.tsx
@@ -107,7 +107,6 @@ const PatientPage = () => {
       email: form.email,
     }
     const userData = {
-      invitationCode: form.invitationCode,
       clinician: form.clinician,
       organization: clinician.organization,
       dateOfBirth: form.dateOfBirth?.toISOString() ?? null,


### PR DESCRIPTION
# Make invitation code readonly

## :recycle: Current situation & Problem
#88 


## :gear: Release Notes 
* Remove invitation code from PatientForm
* Add invitation code to user information

I moved the invitation code to the information panel on the left if it's meant to be read-only. 

![image](https://github.com/user-attachments/assets/50251b77-239f-4c1d-85ca-ffcb810fba68)



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
