### PR TITLE
Remove Stanford mHealth Platform link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Every version of the application on the `main` branch is automatically packaged 
 
 ## Deployment
 
-This repository contains all necessary files to deploy the web frontend to Google Cloud Firebase ([Stanford mHealth Platform](https://med.stanford.edu/mhealth.html)).
+This repository contains all necessary files to deploy the web frontend to Google Cloud Firebase.
 
 ### Deployment Configuration
 


### PR DESCRIPTION
# Remove Stanford mHealth Platform link from README

## :recycle: Current situation & Problem
Link is down, which triggers wrong markdown links actions. 


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
