### PR TITLE
Add `checks: write` permission to production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
+      checks: write
     secrets: inherit
     with:
       environment: production


### PR DESCRIPTION
# Add `checks: write` permission to production workflow

## :recycle: Current situation & Problem
https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/actions/runs/12207185608 run failed due to lack of permissions.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
