### PR TITLE
Sync medication requests data gracefully instead of replacing it every time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^18",
         "react-helmet": "^6.1.0",
         "use-debounce": "^10.0.4",
+        "uuid": "^11.1.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -4097,6 +4098,20 @@
       },
       "peerDependencies": {
         "storybook": "^8.5.3"
+      }
+    },
+    "node_modules/@storybook/addon-actions/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@storybook/addon-backgrounds": {
@@ -12396,17 +12411,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^18",
     "react-helmet": "^6.1.0",
     "use-debounce": "^10.0.4",
+    "uuid": "^11.1.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/routes/~_dashboard/~patients/Medications.tsx
+++ b/routes/~_dashboard/~patients/Medications.tsx
@@ -41,6 +41,7 @@ import {
   useForm,
 } from "@stanfordspezi/spezi-web-design-system/forms";
 import { Plus, Check, Trash, Pencil } from "lucide-react";
+import { v4 as uuid } from "uuid";
 import { z } from "zod";
 import { useMedicationsMap } from "@/routes/~_dashboard/~patients/clientUtils";
 import { MedicationSelect } from "@/routes/~_dashboard/~patients/MedicationSelect";
@@ -97,7 +98,7 @@ export const Medications = ({
     form.setValue("medications", [
       ...formValues.medications,
       {
-        id: `${formValues.medications.length + 1}`,
+        id: uuid(),
         // `undefined` doesn't get submitted anywhere
         medication: undefined as unknown as string,
         drug: undefined as unknown as string,

--- a/routes/~_dashboard/~patients/~$id/~index.tsx
+++ b/routes/~_dashboard/~patients/~$id/~index.tsx
@@ -17,6 +17,7 @@ import {
 import { toast } from "@stanfordspezi/spezi-web-design-system/components/Toaster";
 import { getUserName } from "@stanfordspezi/spezi-web-design-system/modules/auth";
 import { PageTitle } from "@stanfordspezi/spezi-web-design-system/molecules/DashboardLayout";
+import { syncItems } from "@stanfordspezi/spezi-web-design-system/utils/data";
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router";
 import { Contact } from "lucide-react";
 import { Helmet } from "react-helmet";
@@ -142,30 +143,39 @@ const PatientPage = () => {
   };
 
   const saveMedications = async (form: MedicationsFormSchema) => {
-    const medicationRequests = await getDocsData(
-      refs.medicationRequests({ userId, resourceType }),
-    );
+    const freshUserMedication = await getUserMedications({
+      userId,
+      resourceType,
+    });
+    const getMedicationRequestRef = (id: string) =>
+      docRefs.medicationRequest({
+        userId,
+        medicationRequestId: id,
+        resourceType,
+      });
+
     // async is required to match types
     // eslint-disable-next-line @typescript-eslint/require-await
     await runTransaction(db, async (transaction) => {
-      medicationRequests.forEach((medication) => {
-        transaction.delete(
-          docRefs.medicationRequest({
-            userId,
-            medicationRequestId: medication.id,
-            resourceType,
-          }),
-        );
-      });
-      form.medications.forEach((medication) => {
-        transaction.set(
-          docRefs.medicationRequest({
-            userId,
-            medicationRequestId: medication.id,
-            resourceType,
-          }),
-          getMedicationRequestData(medication),
-        );
+      syncItems({
+        newItems: form.medications,
+        oldItems: freshUserMedication,
+        getId: (medication) => medication.id,
+        onDelete: (id) => {
+          transaction.delete(getMedicationRequestRef(id));
+        },
+        onCreate: (id, medication) => {
+          transaction.set(
+            getMedicationRequestRef(id),
+            getMedicationRequestData(medication),
+          );
+        },
+        onUpdate: (id, medication) => {
+          transaction.set(
+            getMedicationRequestRef(id),
+            getMedicationRequestData(medication),
+          );
+        },
       });
     });
   };

--- a/routes/~_dashboard/~patients/~$id/~index.tsx
+++ b/routes/~_dashboard/~patients/~$id/~index.tsx
@@ -143,7 +143,7 @@ const PatientPage = () => {
   };
 
   const saveMedications = async (form: MedicationsFormSchema) => {
-    const freshUserMedication = await getUserMedications({
+    const freshUserMedications = await getUserMedications({
       userId,
       resourceType,
     });
@@ -159,7 +159,7 @@ const PatientPage = () => {
     await runTransaction(db, async (transaction) => {
       syncItems({
         newItems: form.medications,
-        oldItems: freshUserMedication,
+        oldItems: freshUserMedications,
         getId: (medication) => medication.id,
         onDelete: (id) => {
           transaction.delete(getMedicationRequestRef(id));


### PR DESCRIPTION
# Sync medication requests data gracefully instead of replacing it every time

⚠️ Do not merge yet. Needs https://github.com/StanfordSpezi/spezi-web-design-system/pull/45 to be merged. 

## :recycle: Current situation & Problem
Replacing medication requests every time is:
1. Not very effective
2. Might cause other problems down the line, for example when resolving this: https://github.com/StanfordBDHG/ENGAGE-HF-Firebase/issues/221

After PR, data is saved only if needed, therefore it's simpler for BE to handle notifications. 


## :gear: Release Notes 
* Sync medication requests data gracefully instead of replacing it every time


## :white_check_mark: Testing
Tested manually ✅ 


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
