### PR TITLE
Revalidate notifications page on actions

### DIFF
--- a/modules/notifications/Notification.tsx
+++ b/modules/notifications/Notification.tsx
@@ -11,12 +11,12 @@ import {
   Notification as NotificationBase,
   NotificationActions,
   NotificationContentContainer,
+  NotificationHeader,
   NotificationImage,
   NotificationLink,
   NotificationMessage,
   NotificationTime,
   NotificationTitle,
-  NotificationHeader,
 } from "@stanfordspezi/spezi-web-design-system/molecules/Notifications";
 import { useMutation } from "@tanstack/react-query";
 import { callables } from "@/modules/firebase/app";
@@ -30,8 +30,7 @@ import {
   isMessageRead,
   parseMessageToLink,
 } from "@/modules/notifications/helpers";
-import { notificationQueries } from "@/modules/notifications/queries";
-import { queryClient } from "@/modules/query/queryClient";
+import { useNotificationActions } from "@/modules/notifications/queries";
 
 interface NotificationProps {
   notification: UserMessage;
@@ -39,16 +38,14 @@ interface NotificationProps {
 
 export const Notification = ({ notification }: NotificationProps) => {
   const { auth } = useUser();
+  const { invalidateUserNotifications } = useNotificationActions();
   const markNotificationAsRead = useMutation({
     mutationFn: () =>
       callables.dismissMessage({
         userId: auth.uid,
         messageId: notification.id,
       }),
-    onSuccess: async () =>
-      queryClient.invalidateQueries(
-        notificationQueries.list({ userId: auth.uid }),
-      ),
+    onSuccess: invalidateUserNotifications,
   });
 
   const isRead = isMessageRead(notification);

--- a/modules/notifications/NotificationsTable/MarkAllAsReadButton.tsx
+++ b/modules/notifications/NotificationsTable/MarkAllAsReadButton.tsx
@@ -14,8 +14,7 @@ import { callables } from "@/modules/firebase/app";
 import { type UserMessage } from "@/modules/firebase/models";
 import { useUser } from "@/modules/firebase/UserProvider";
 import { isMessageRead } from "@/modules/notifications/helpers";
-import { notificationQueries } from "@/modules/notifications/queries";
-import { queryClient } from "@/modules/query/queryClient";
+import { useNotificationActions } from "@/modules/notifications/queries";
 
 interface MarkAllAsReadButtonProps {
   notifications: UserMessage[];
@@ -25,6 +24,7 @@ export const MarkAllAsReadButton = ({
   notifications,
 }: MarkAllAsReadButtonProps) => {
   const { auth } = useUser();
+  const { invalidateUserNotifications } = useNotificationActions();
 
   const dismissibleNotifications = useMemo(
     () =>
@@ -45,10 +45,7 @@ export const MarkAllAsReadButton = ({
           (notification) => notification.id,
         ),
       }),
-    onSuccess: async () =>
-      queryClient.invalidateQueries(
-        notificationQueries.list({ userId: auth.uid }),
-      ),
+    onSuccess: invalidateUserNotifications,
   });
 
   return (

--- a/modules/notifications/queries.tsx
+++ b/modules/notifications/queries.tsx
@@ -12,6 +12,7 @@ import { refs } from "@/modules/firebase/app";
 import { useUser } from "@/modules/firebase/UserProvider";
 import { getDocsData } from "@/modules/firebase/utils";
 import { filterUnreadNotifications } from "@/modules/notifications/helpers";
+import { queryClient } from "@/modules/query/queryClient";
 
 interface ListNotificationsPayload {
   userId: string;
@@ -41,4 +42,15 @@ export const useHasUnreadNotification = () => {
   });
 
   return { hasUnreadNotification };
+};
+
+export const useNotificationActions = () => {
+  const { auth } = useUser();
+
+  const invalidateUserNotifications = () =>
+    queryClient.invalidateQueries(
+      notificationQueries.list({ userId: auth.uid }),
+    );
+
+  return { invalidateUserNotifications };
 };

--- a/routes/~_dashboard/~notifications/~index.tsx
+++ b/routes/~_dashboard/~notifications/~index.tsx
@@ -7,17 +7,24 @@
 //
 
 import { PageTitle } from "@stanfordspezi/spezi-web-design-system/molecules/DashboardLayout";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Bell } from "lucide-react";
 import { Helmet } from "react-helmet";
-import { currentUserQueryOptions } from "@/modules/firebase/UserProvider";
+import {
+  currentUserQueryOptions,
+  useUser,
+} from "@/modules/firebase/UserProvider";
 import { NotificationsTable } from "@/modules/notifications/NotificationsTable";
 import { notificationQueries } from "@/modules/notifications/queries";
 import { queryClient } from "@/modules/query/queryClient";
 import { DashboardLayout } from "../DashboardLayout";
 
 const NotificationsPage = () => {
-  const { notifications } = Route.useLoaderData();
+  const { auth } = useUser();
+  const { data: notifications } = useSuspenseQuery(
+    notificationQueries.list({ userId: auth.uid }),
+  );
 
   return (
     <DashboardLayout
@@ -35,11 +42,8 @@ export const Route = createFileRoute("/_dashboard/notifications/")({
   component: NotificationsPage,
   loader: async () => {
     const user = await queryClient.ensureQueryData(currentUserQueryOptions());
-
-    return {
-      notifications: await queryClient.ensureQueryData(
-        notificationQueries.list({ userId: user.auth.uid }),
-      ),
-    };
+    await queryClient.ensureQueryData(
+      notificationQueries.list({ userId: user.auth.uid }),
+    );
   },
 });


### PR DESCRIPTION
# Revalidate notifications page on actions

## :recycle: Current situation & Problem
Closes #128 


## :gear: Release Notes 
* Use query to revalidate notifications on action
* Centralize invalidation


## :white_check_mark: Testing
Tested manually


https://github.com/user-attachments/assets/85184642-bdbb-4783-a7d7-1c4a8104d34b




### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
