### PR TITLE
Fix misplaced SSO icons on Safari

### DIFF
--- a/routes/~sign-in/~index.tsx
+++ b/routes/~sign-in/~index.tsx
@@ -28,7 +28,13 @@ const SignIn = () => (
         {
           name: "Stanford",
           provider: authProvider.stanford,
-          icon: <img src={stanfordLogoImg} alt="Stanford University logo" />,
+          icon: (
+            <img
+              src={stanfordLogoImg}
+              alt="Stanford University logo"
+              className="w-[22px]"
+            />
+          ),
         },
         {
           name: "Johns Hopkins",
@@ -37,13 +43,20 @@ const SignIn = () => (
             <img
               src={johnsHopkingsLogoImg}
               alt="Johns Hopkins University logo"
+              className="w-[32px]"
             />
           ),
         },
         {
           name: "Michigan",
           provider: authProvider.michigan,
-          icon: <img src={michiganLogoImg} alt="University of Michigan logo" />,
+          icon: (
+            <img
+              src={michiganLogoImg}
+              alt="University of Michigan logo"
+              className="w-[51px]"
+            />
+          ),
         },
       ]}
       enableEmailPassword={env.VITE_PUBLIC_EMAIL_PASSWORD_SIGN_IN}


### PR DESCRIPTION
# Fix misplaced SSO icons on Safari

## :recycle: Current situation & Problem
Closes #131 


## :gear: Release Notes 
* Fix misplaced SSO icons on Safari


## :white_check_mark: Testing
<img width="981" alt="image" src="https://github.com/user-attachments/assets/1bfb0ee9-75fe-449f-bfb3-e8696ba07a10" />



### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
