### PR TITLE
Fix Calendar start month

### DIFF
--- a/routes/~_dashboard/~patients/PatientForm.tsx
+++ b/routes/~_dashboard/~patients/PatientForm.tsx
@@ -99,7 +99,10 @@ export const PatientForm = ({
             selected={field.value}
             onSelect={(date) => field.onChange(date)}
             defaultMonth={field.value}
-            endMonth={new Date(new Date().getFullYear(), 0)}
+            endMonth={new Date()}
+            hidden={{
+              after: new Date(),
+            }}
           />
         )}
       />

--- a/routes/~_dashboard/~patients/~$id/AppointmentForm.tsx
+++ b/routes/~_dashboard/~patients/~$id/AppointmentForm.tsx
@@ -77,6 +77,7 @@ export const AppointmentForm = ({
             hidden={{
               before: new Date(),
             }}
+            startMonth={new Date()}
             showTimePicker
           />
         )}

--- a/routes/~_dashboard/~patients/~$id/LabForm.tsx
+++ b/routes/~_dashboard/~patients/~$id/LabForm.tsx
@@ -155,7 +155,10 @@ export const LabForm = ({ observation, onSubmit }: LabFormProps) => {
             selected={field.value}
             onSelect={(date) => field.onChange(date)}
             defaultMonth={field.value}
-            endMonth={new Date(new Date().getFullYear(), 0)}
+            endMonth={new Date()}
+            hidden={{
+              after: new Date(),
+            }}
           />
         )}
       />


### PR DESCRIPTION
# Fix Calendar start month

## :recycle: Current situation & Problem
Date picker component was updated with https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/pull/141 updates, couple breaking changes. Updated start month logic was simply wrong by mistake.


## :gear: Release Notes
* Fix Calendar start month

![image](https://github.com/user-attachments/assets/f4459439-26b2-4821-a941-3be01f596964)
![image](https://github.com/user-attachments/assets/2cf466b8-afe8-4cea-bf87-0f6ce2b2e892)
![image](https://github.com/user-attachments/assets/a650fae2-d3f1-4b1c-b12e-d1210a92de21)





### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
