### PR TITLE
Add self-managed support

### DIFF
--- a/modules/user/patients.ts
+++ b/modules/user/patients.ts
@@ -42,6 +42,7 @@ export const parsePatientsQueries = async ({
     { userIds, includeUserData: true },
     ({ auth, user }, id) => ({
       ...parseAuthToUser(id, auth),
+      selfManaged: user?.selfManaged,
       organization: organizationMap.get(user?.organization ?? ""),
       disabled: user?.disabled,
     }),

--- a/modules/user/queries.tsx
+++ b/modules/user/queries.tsx
@@ -39,6 +39,7 @@ export const parseInvitationToUser = (
   organization: organizationMap.get(invitation.user.organization ?? ""),
   type: invitation.user.type,
   disabled: invitation.user.disabled,
+  selfManaged: invitation.user.selfManaged,
 });
 
 export const parseAuthToUser = (

--- a/routes/~_dashboard/~patients/PatientForm.tsx
+++ b/routes/~_dashboard/~patients/PatientForm.tsx
@@ -27,11 +27,16 @@ import {
 } from "@stanfordspezi/spezi-web-design-system/modules/auth";
 import { z } from "zod";
 import { type User } from "@/modules/firebase/models";
+import { SideLabel } from "@stanfordspezi/spezi-web-design-system/components/SideLabel";
+import { Checkbox } from "@stanfordspezi/spezi-web-design-system/components/Checkbox";
+import { Tooltip } from "@stanfordspezi/spezi-web-design-system/components/Tooltip";
+import { Info } from "lucide-react";
 
 export const patientFormSchema = z.object({
   displayName: z.string(),
   clinician: z.string().min(1, "Clinician is required"),
   dateOfBirth: z.date().optional(),
+  selfManaged: z.boolean(),
   providerName: z.preprocess(
     (value) => (value === "" ? null : value),
     z.string().nullable(),
@@ -49,7 +54,11 @@ interface PatientFormProps {
   userInfo?: Pick<UserInfo, "email" | "displayName" | "uid">;
   user?: Pick<
     User,
-    "organization" | "clinician" | "dateOfBirth" | "providerName"
+    | "organization"
+    | "clinician"
+    | "dateOfBirth"
+    | "providerName"
+    | "selfManaged"
   >;
   onSubmit: (data: PatientFormSchema) => Promise<void>;
   clinicianPreselectId?: string;
@@ -70,6 +79,7 @@ export const PatientForm = ({
       clinician: user?.clinician ?? clinicianPreselectId ?? "",
       dateOfBirth: user?.dateOfBirth ? new Date(user.dateOfBirth) : undefined,
       providerName: user?.providerName ?? "",
+      selfManaged: user?.selfManaged ?? false,
     },
   });
 
@@ -137,6 +147,34 @@ export const PatientForm = ({
         }
         render={({ field }) => <Input {...field} value={field.value ?? ""} />}
       />
+      {!isEdit && (
+        <Field
+          control={form.control}
+          name="selfManaged"
+          render={({ field }) => {
+            const { value, onChange, ...restField } = field;
+            return (
+              <div className="flex items-center gap-2">
+                <SideLabel label="Is self enrolled">
+                  <Checkbox
+                    checked={value}
+                    onCheckedChange={onChange}
+                    {...restField}
+                  />
+                </SideLabel>
+                <Tooltip tooltip="This feature allows patients to enter their own medication and laboratory value updates.">
+                  <button
+                    type="button"
+                    className="interactive-opacity text-muted-foreground size-4 rounded-md"
+                  >
+                    <Info className="size-full" />
+                  </button>
+                </Tooltip>
+              </div>
+            );
+          }}
+        />
+      )}
       <Button type="submit" isPending={form.formState.isSubmitting}>
         {isEdit ? "Update" : "Invite"} patient
       </Button>

--- a/routes/~_dashboard/~patients/PatientForm.tsx
+++ b/routes/~_dashboard/~patients/PatientForm.tsx
@@ -155,7 +155,7 @@ export const PatientForm = ({
             const { value, onChange, ...restField } = field;
             return (
               <div className="flex items-center gap-2">
-                <SideLabel label="Is self enrolled">
+                <SideLabel label="Is self managed">
                   <Checkbox
                     checked={value}
                     onCheckedChange={onChange}

--- a/routes/~_dashboard/~patients/PatientsTable.tsx
+++ b/routes/~_dashboard/~patients/PatientsTable.tsx
@@ -20,6 +20,7 @@ import { createSharedUserColumns, userColumnIds } from "@/modules/user/table";
 import { PatientMenu } from "@/routes/~_dashboard/~patients/PatientMenu";
 import { type Patient } from "@/routes/~_dashboard/~patients/~index";
 import { useNavigateOrOpen } from "@/utils/useNavigateOrOpen";
+import { Check } from "lucide-react";
 
 const columnHelper = createColumnHelper<Patient>();
 const userColumns = createSharedUserColumns<Patient>();
@@ -29,6 +30,13 @@ const columns = [
   userColumns.email,
   userColumns.organization,
   userColumns.disabled,
+  columnHelper.accessor("selfManaged", {
+    header: "Self Managed",
+    cell: (props) => {
+      const selfManaged = props.getValue();
+      return selfManaged ? <Check className="size-5" /> : "";
+    },
+  }),
   columnHelper.display({
     id: "actions",
     cell: (props) => <PatientMenu patient={props.row.original} />,

--- a/routes/~_dashboard/~patients/utils.ts
+++ b/routes/~_dashboard/~patients/utils.ts
@@ -239,6 +239,7 @@ export const getPatientInfo = async ({
     latestQuestionnaireDate: latestQuestionnaires.at(0)?.authored,
     invitationCode: user.invitationCode,
     isInvitation: resourceType === "invitation",
+    selfManaged: user.selfManaged,
   };
 };
 

--- a/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
+++ b/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
@@ -8,7 +8,14 @@
 
 import { Card } from "@stanfordspezi/spezi-web-design-system/components/Card";
 import { formatNilDateTime } from "@stanfordspezi/spezi-web-design-system/utils/date";
-import { Clock, FileQuestion, Mail, BookLock, AtSign } from "lucide-react";
+import {
+  Clock,
+  FileQuestion,
+  Mail,
+  BookLock,
+  AtSign,
+  FileInput,
+} from "lucide-react";
 import { type ReactNode } from "react";
 import { type PatientInfo as PatientInfoData } from "@/routes/~_dashboard/~patients/utils";
 
@@ -51,6 +58,13 @@ export const PatientInfo = ({ info }: PatientInfoProps) => (
             icon={<Mail className="size-5" />}
             label="Invitation"
             value="patient has not yet logged in"
+          />
+        )}
+        {info.selfManaged && (
+          <InfoRow
+            icon={<FileInput className="size-5" />}
+            label="Self managed"
+            value="inputs data themselves"
           />
         )}
         <InfoRow

--- a/routes/~_dashboard/~patients/~invite.tsx
+++ b/routes/~_dashboard/~patients/~invite.tsx
@@ -40,6 +40,7 @@ const InvitePatientPage = () => {
         organization: clinician.organization,
         dateOfBirth: form.dateOfBirth?.toISOString(),
         providerName: form.providerName,
+        selfManaged: form.selfManaged,
       },
     });
     toast.success("Patient has been successfully invited!");


### PR DESCRIPTION
# Add self-managed support

## :recycle: Current situation & Problem
This PR adds support for marking patients as self managed.


## :gear: Release Notes
* Add "self managed" checkbox to patient form in create mode
* Expose "self managed" property in the table


## :white_check_mark: Testing
Tested manually


1. Both invitations and regular patients in the table marked as self managed

![image](https://github.com/user-attachments/assets/4a96a973-5d62-45fa-8ca3-18123051102d)


2. Indicator that patient is self managed in the edit view

![image](https://github.com/user-attachments/assets/a8910a5f-d298-4835-9b0e-9e45e498b2cc)

3. Invite form

![image](https://github.com/user-attachments/assets/79c0396b-979b-414f-984b-f87b4743c05e)




### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
