### PR TITLE
Bring back the email field to edit patients

### DIFF
--- a/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
+++ b/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
@@ -8,14 +8,7 @@
 
 import { Card } from "@stanfordspezi/spezi-web-design-system/components/Card";
 import { formatNilDateTime } from "@stanfordspezi/spezi-web-design-system/utils/date";
-import {
-  Clock,
-  FileQuestion,
-  Mail,
-  BookLock,
-  AtSign,
-  FileInput,
-} from "lucide-react";
+import { Clock, FileQuestion, Mail, BookLock, FileInput } from "lucide-react";
 import { type ReactNode } from "react";
 import { type PatientInfo as PatientInfoData } from "@/routes/~_dashboard/~patients/utils";
 
@@ -43,11 +36,6 @@ export const PatientInfo = ({ info }: PatientInfoProps) => (
   <Card className="xl:min-w-max xl:self-start">
     <div className="px-5 py-4">
       <ul className="flex flex-col gap-4">
-        <InfoRow
-          icon={<AtSign className="size-5" />}
-          label="Email"
-          value={info.email ?? "no email"}
-        />
         <InfoRow
           icon={<BookLock className="size-5" />}
           label="Invitation code"

--- a/routes/~_dashboard/~patients/~$id/~index.tsx
+++ b/routes/~_dashboard/~patients/~$id/~index.tsx
@@ -125,7 +125,10 @@ const PatientPage = () => {
       await callables.updateUserInformation({
         userId,
         data: {
-          auth: authData,
+          auth: {
+            ...authData,
+            email: form.email,
+          },
         },
       });
       await updateDoc(docRefs.user(userId), userData);
@@ -233,6 +236,7 @@ const PatientPage = () => {
               user={user}
               userInfo={authUser}
               onSubmit={updatePatient}
+              resourceType={resourceType}
               {...formProps}
             />
           </div>


### PR DESCRIPTION
# Bring back the email field to edit patients


https://github.com/user-attachments/assets/f2a805a9-07c2-4d20-a500-47c389a12b71

![image](https://github.com/user-attachments/assets/71c82807-23af-4a06-b037-c8eb036821c0)




## :recycle: Current situation & Problem
Clinicians sometimes need to modify patients' email.


## :gear: Release Notes
* Brings back email field to edit patients. Field is not visible for inviting patients or editing invitations - only editing patients that signed up to the application. 


## :white_check_mark: Testing
Tested manually.


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
