### PR TITLE
Fix Tailwind @source path after src/ migration

### DIFF
--- a/src/modules/globals.css
+++ b/src/modules/globals.css
@@ -11,4 +11,4 @@ SPDX-License-Identifier: MIT
 @import '@stanfordspezi/spezi-web-design-system/tailwind.css';
 @import '@stanfordspezi/spezi-web-design-system/base.css';
 
-@source '../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js';
+@source '../../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js';


### PR DESCRIPTION
## :recycle: Current situation & Problem
On staging (e.g. https://engagehf-qa.med.stanford.edu/sign-in) most Tailwind styles are missing because Tailwind is not detecting the design system's classes at build time.

Root cause: the "Migrate to src directory" change (#178) moved `modules/globals.css` to `src/modules/globals.css` as a pure file move, but the `@source` directive inside it uses a path relative to the CSS file:

```css
@source '../node_modules/@stanfordspezi/spezi-web-design-system/dist/**/*.js';
```

After the move this resolves to `src/node_modules/...`, which does not exist. Tailwind v4 excludes `node_modules` from automatic scanning, so this explicit `@source` is the only thing pulling in the `spezi-web-design-system` component classes. With the glob pointing at a missing folder, none of those utilities are generated. Since the sign-in page is built almost entirely from design system components, most of its styling disappears.

## :gear: Release Notes
- Fixed the `@source` path in `src/modules/globals.css` (`../node_modules/...` -> `../../node_modules/...`) so Tailwind again scans the `@stanfordspezi/spezi-web-design-system` compiled components.
- Restores the missing styles across pages that rely on design system components (including sign-in).
- No public API or behavior changes.

## :books: Documentation
No public API changes. This is a build configuration fix only.

## :white_check_mark: Testing
Verified the path regression by tracing the relative `@source` resolution before and after the `src/` migration. Recommend confirming with a production build (`npm run build`) and loading `/sign-in` on a preview to see the design system styles applied.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
