### PR TITLE
Adopt the Organization Repository Standards

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+#
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
+#
+# SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+version: 2
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,9 @@ jobs:
     uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
   markdownlinkcheck:
     name: Markdown Link Check
+    permissions:
+      contents: read
+      pull-requests: read
     uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
   eslint:
     name: ESLint

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -20,24 +20,24 @@ on:
 jobs:
   reuseaction:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
   markdownlinkcheck:
     name: Markdown Link Check
-    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
   eslint:
     name: ESLint
-    uses: StanfordBDHG/.github/.github/workflows/eslint.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/eslint.yml@v0.5
     permissions:
       contents: read
       checks: write
   testandcoverage:
     name: Test and Coverage
-    uses: StanfordBDHG/.github/.github/workflows/npm-test-and-coverage.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/npm-test-coverage.yml@v0.5
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}
   dockercomposetest:
     name: Docker Compose & Test
-    uses: StanfordBDHG/.github/.github/workflows/docker-compose-test.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/docker-compose-test.yml@v0.5
     with:
       dockerComposeFile: docker-compose-development.yml
       testscript: test.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,6 +36,8 @@ jobs:
   testandcoverage:
     name: Test and Coverage
     uses: SchmiedmayerLab/.github/.github/workflows/npm-test-coverage.yml@v0.5
+    with:
+      nodeVersionFile: package.json
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}
   dockercomposetest:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -75,7 +75,7 @@ jobs:
   deployfirebase:
     name: Deploy Firebase Project
     needs: [buildandtest, determineenvironment, vars]
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/firebase-deploy.yml@v0.5
     permissions:
       contents: read
     with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -50,9 +50,9 @@ jobs:
         id: set-env
         run: |
           if [[ -z "${{ inputs.environment }}" ]]; then
-            echo "environment=staging" >> $GITHUB_OUTPUT
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
           else
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+            echo "environment=${{ inputs.environment }}" >> "$GITHUB_OUTPUT"
           fi
   vars:
     name: Inject Environment Variables In Deployment Workflow

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -71,6 +71,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: read
     secrets: inherit
   deployfirebase:
     name: Deploy Firebase Project

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -15,4 +15,4 @@ on:
 jobs:
   markdown_link_check:
     name: Markdown Link Check
-    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -15,4 +15,7 @@ on:
 jobs:
   markdown_link_check:
     name: Markdown Link Check
+    permissions:
+      contents: read
+      pull-requests: read
     uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -27,6 +27,7 @@ jobs:
       actions: read
       security-events: write
       checks: write
+      pull-requests: read
     secrets: inherit
     with:
       environment: production

--- a/.github/workflows/repository-standards.yml
+++ b/.github/workflows/repository-standards.yml
@@ -1,0 +1,24 @@
+#
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+
+name: Repository Standards
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  standards:
+    name: Standards
+    uses: SchmiedmayerLab/.github/.github/workflows/repository-standards.yml@v0.5

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
@@ -8,14 +8,17 @@
 
 cff-version: 1.2.0
 message: 'If you use this software, please cite it as below.'
+type: software
 authors:
+  - family-names: 'Bachorski'
+    given-names: 'Arkadiusz'
+  - family-names: 'Kraft'
+    given-names: 'Paul Johannes'
+    orcid: 'https://orcid.org/0000-0001-8157-8151'
   - family-names: 'Schmiedmayer'
     given-names: 'Paul'
     orcid: 'https://orcid.org/0000-0002-8607-9148'
-  - family-names: 'Ravi'
-    given-names: 'Vishnu'
-    orcid: 'https://orcid.org/0000-0003-0359-1275'
-  - family-names: 'Arkadiusz'
-    given-names: 'Bachorski'
 title: 'ENGAGE-HF Web Frontend'
-url: 'https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend'
+license: MIT
+url: "https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend"
+repository-code: "https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend"

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,6 @@
 <!--
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 
@@ -8,7 +8,12 @@ SPDX-License-Identifier: MIT
 
 -->
 
-# Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# ENGAGE-HF Web Frontend Contributors
 
 - [Arkadiusz Bachorski](https://github.com/arkadiuszbachorski)
+- [Paul Johannes Kraft](https://github.com/pauljohanneskraft)
 - [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
+
+## Attributions
+
+This repository builds on [`spezi-web-design-system`](https://github.com/StanfordSpezi/spezi-web-design-system) and [`spezi-web-configurations`](https://github.com/StanfordSpezi/spezi-web-configurations), published under the MIT License (Copyright (c) 2024 Stanford University and the project authors). They are developed independently; please refer to the [Stanford Spezi contributors list](https://github.com/StanfordSpezi/Spezi/blob/main/CONTRIBUTORS.md) for past and current contributors across the Spezi projects.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 # Based on the docker file found at https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile.
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!--
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 
@@ -8,11 +8,14 @@ SPDX-License-Identifier: MIT
 
 -->
 
-# Stanford Biodesign Digital Health ENGAGE-HF Web Frontend
+# ENGAGE-HF Web Frontend
 
-[![Build and Test](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/actions/workflows/build-and-test.yml)
-[![Deployment](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/actions/workflows/deployment.yml/badge.svg)](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/actions/workflows/deployment.yml)
-[![codecov](https://codecov.io/gh/StanfordBDHG/ENGAGE-HF-Web-Frontend/graph/badge.svg?token=PsKyNz7Woe)](https://codecov.io/gh/StanfordBDHG/ENGAGE-HF-Web-Frontend)
+[![Build and Test](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/build-and-test.yml)
+[![Deployment](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/deployment.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/deployment.yml)
+[![CodeQL](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/codeql.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/codeql.yml)
+[![Codecov](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/graph/badge.svg?token=PsKyNz7Woe)](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)
+[![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)](https://api.reuse.software/info/github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/blob/main/LICENSE.md)
 
 Web Frontend for the ENGAGE-HF project.
 
@@ -87,14 +90,21 @@ This repository contains all necessary files to deploy the web frontend to Googl
 
 ...
 
+## Contributing
+
+Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) first. You can find a list of contributors in the [CONTRIBUTORS.md](CONTRIBUTORS.md) file.
+
 ## License
 
-This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/tree/main/LICENSES) for more information.
+This project is licensed under the MIT License. See [LICENSE.md](LICENSE.md) for more information.
 
-## Contributors
+## Citation
 
-This project is developed as part of the Stanford Byers Center for Biodesign at Stanford University.
-See [CONTRIBUTORS.md](https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend/tree/main/CONTRIBUTORS.md) for a full list of all contributors.
+If you use this software, please cite it using the metadata in [CITATION.cff](CITATION.cff), which GitHub surfaces through the [*Cite this repository*](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) button.
 
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
-![Stanford Byers Center for Biodesign Logo](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)
+## Our Research
+
+For more information, visit the [Schmiedmayer Lab GitHub organization](https://github.com/SchmiedmayerLab).
+
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-light.png#gh-light-mode-only)
+![Schmiedmayer Lab](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/footer-dark.png#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project uses Node.js v22. Install Node.js, e.g. using [nvm](https://github.
 
 In order to use Web Frontend, you need to use actual Firebase environment or Emulator with seeded data. For developing locally, it's best to use the Emulator.
 
-1. Clone `https://github.com/StanfordBDHG/ENGAGE-HF-Firebase` repository
+1. Clone `https://github.com/SchmiedmayerLab/ENGAGE-HF-Firebase` repository
 
 2. In the root of ENGAGE-HF-Firebase run:
 
@@ -47,7 +47,7 @@ npm run prepare && npm run serve:seeded
 
 Repeat step 2 each time files have changed.
 
-Refer to [ENGAGE-HF-Firebase](https://github.com/StanfordBDHG/ENGAGE-HF-Firebase) repository for more details.
+Refer to [ENGAGE-HF-Firebase](https://github.com/SchmiedmayerLab/ENGAGE-HF-Firebase) repository for more details.
 
 ### Dashboard
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
 [![CodeQL](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/codeql.yml/badge.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/actions/workflows/codeql.yml)
 [![Codecov](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/graph/badge.svg?token=PsKyNz7Woe)](https://codecov.io/gh/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)
 [![REUSE status](https://api.reuse.software/badge/github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)](https://api.reuse.software/info/github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend/blob/main/LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 
 Web Frontend for the ENGAGE-HF project.
 

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 #

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 # Based on the Apodini workflow found at: https://github.com/Apodini/ApodiniExample/docker-compose-development.yml
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 # Based on the Apodini workflow found at: https://github.com/Apodini/ApodiniExample/docker-compose.yml
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/firebase.json.license
+++ b/firebase.json.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!--
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 # Based on the docker file found at https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile.
 #
 # SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "Stanford",
     "Biodesign"
   ],
+  "packageManager": "npm@11.12.1",
   "engines": {
     "node": "24"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/StanfordBDHG/ENGAGE-HF-Web-Frontend"
+    "url": "https://github.com/SchmiedmayerLab/ENGAGE-HF-Web-Frontend"
   },
   "private": true,
   "scripts": {

--- a/package.json.license
+++ b/package.json.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/public/favicon.ico.license
+++ b/public/favicon.ico.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/public/stanfordbiodesign.png.license
+++ b/public/stanfordbiodesign.png.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/resources/appScreenshot.png.license
+++ b/resources/appScreenshot.png.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/src/components/AsideEngageLayout/AsideEngageLayout.tsx
+++ b/src/components/AsideEngageLayout/AsideEngageLayout.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/components/AsideEngageLayout/index.tsx
+++ b/src/components/AsideEngageLayout/index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/components/NotFound/NotFound.tsx
+++ b/src/components/NotFound/NotFound.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/components/NotFound/index.tsx
+++ b/src/components/NotFound/index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/components/icons/Logo.tsx
+++ b/src/components/icons/Logo.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/components/icons/LogoType.tsx
+++ b/src/components/icons/LogoType.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/AuthProvider.ts
+++ b/src/modules/firebase/AuthProvider.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/UserProvider.tsx
+++ b/src/modules/firebase/UserProvider.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/allergy.ts
+++ b/src/modules/firebase/allergy.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/app.ts
+++ b/src/modules/firebase/app.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/appointment.ts
+++ b/src/modules/firebase/appointment.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/config.ts
+++ b/src/modules/firebase/config.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/localizedText.test.ts
+++ b/src/modules/firebase/localizedText.test.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/localizedText.ts
+++ b/src/modules/firebase/localizedText.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/medication.ts
+++ b/src/modules/firebase/medication.ts
@@ -1,5 +1,5 @@
 ///
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/models.ts
+++ b/src/modules/firebase/models.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/role.ts
+++ b/src/modules/firebase/role.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/user.ts
+++ b/src/modules/firebase/user.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/firebase/utils.ts
+++ b/src/modules/firebase/utils.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/globals.css
+++ b/src/modules/globals.css
@@ -1,6 +1,6 @@
 /*
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/src/modules/notifications/Notification.tsx
+++ b/src/modules/notifications/Notification.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/NotificationsTable/MarkAllAsReadButton.tsx
+++ b/src/modules/notifications/NotificationsTable/MarkAllAsReadButton.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/NotificationsTable/ShowUnreadOnlySwitch.tsx
+++ b/src/modules/notifications/NotificationsTable/ShowUnreadOnlySwitch.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/NotificationsTable/helpers.tsx
+++ b/src/modules/notifications/NotificationsTable/helpers.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/NotificationsTable/index.tsx
+++ b/src/modules/notifications/NotificationsTable/index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/helpers.ts
+++ b/src/modules/notifications/helpers.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/notifications/queries.tsx
+++ b/src/modules/notifications/queries.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/query/ReactQueryClientProvider.tsx
+++ b/src/modules/query/ReactQueryClientProvider.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/query/queryClient.ts
+++ b/src/modules/query/queryClient.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/routes.ts
+++ b/src/modules/routes.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/tests/helpers.tsx
+++ b/src/modules/tests/helpers.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/user/ToggleUserDisabled.tsx
+++ b/src/modules/user/ToggleUserDisabled.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/user/patients.ts
+++ b/src/modules/user/patients.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/user/queries.tsx
+++ b/src/modules/user/queries.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/modules/user/table.tsx
+++ b/src/modules/user/table.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/reset.d.ts
+++ b/src/reset.d.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~__root.tsx
+++ b/src/routes/~__root.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard.tsx
+++ b/src/routes/~_dashboard.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/DashboardLayout.tsx
+++ b/src/routes/~_dashboard/DashboardLayout.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/MenuLinks.tsx
+++ b/src/routes/~_dashboard/MenuLinks.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/NotificationsCard.tsx
+++ b/src/routes/~_dashboard/NotificationsCard.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/UpcomingAppointmentsCard.tsx
+++ b/src/routes/~_dashboard/UpcomingAppointmentsCard.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/User.tsx
+++ b/src/routes/~_dashboard/User.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/YourPatientsCard.tsx
+++ b/src/routes/~_dashboard/YourPatientsCard.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~admin/~index.tsx
+++ b/src/routes/~_dashboard/~admin/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~index.tsx
+++ b/src/routes/~_dashboard/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~notifications/~index.tsx
+++ b/src/routes/~_dashboard/~notifications/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/MedicationSelect.tsx
+++ b/src/routes/~_dashboard/~patients/MedicationSelect.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/Medications.tsx
+++ b/src/routes/~_dashboard/~patients/Medications.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/PatientForm.tsx
+++ b/src/routes/~_dashboard/~patients/PatientForm.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/PatientMenu.tsx
+++ b/src/routes/~_dashboard/~patients/PatientMenu.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/PatientsTable.tsx
+++ b/src/routes/~_dashboard/~patients/PatientsTable.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/actions.tsx
+++ b/src/routes/~_dashboard/~patients/actions.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/clientUtils.ts
+++ b/src/routes/~_dashboard/~patients/clientUtils.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/utils.ts
+++ b/src/routes/~_dashboard/~patients/utils.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/Allergies.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/Allergies.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/AllergyForm.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/AllergyForm.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/AppointmentForm.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/AppointmentForm.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/Appointments.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/Appointments.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/ExportUserData.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/ExportUserData.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/GenerateHealthSummary.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/GenerateHealthSummary.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/LabForm.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/LabForm.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/Labs.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/Labs.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/Measurements.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/Measurements.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/Notifications.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/Notifications.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/PatientInfo.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~$id/~index.tsx
+++ b/src/routes/~_dashboard/~patients/~$id/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~index.tsx
+++ b/src/routes/~_dashboard/~patients/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~patients/~invite.tsx
+++ b/src/routes/~_dashboard/~patients/~invite.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/UserForm.tsx
+++ b/src/routes/~_dashboard/~users/UserForm.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/UserMenu.tsx
+++ b/src/routes/~_dashboard/~users/UserMenu.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/UsersTable.tsx
+++ b/src/routes/~_dashboard/~users/UsersTable.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/~$id.tsx
+++ b/src/routes/~_dashboard/~users/~$id.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/~index.tsx
+++ b/src/routes/~_dashboard/~users/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~_dashboard/~users/~invite.tsx
+++ b/src/routes/~_dashboard/~users/~invite.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~patients/~$userId/~healthSummary/~$shareCodeId/~index.tsx
+++ b/src/routes/~patients/~$userId/~healthSummary/~$shareCodeId/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/routes/~sign-in/johnsHopkinsLogo.png.license
+++ b/src/routes/~sign-in/johnsHopkinsLogo.png.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: Johns Hopkins University
 

--- a/src/routes/~sign-in/michiganLogo.png.license
+++ b/src/routes/~sign-in/michiganLogo.png.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: University of Michigan
 

--- a/src/routes/~sign-in/stanfordLogo.png.license
+++ b/src/routes/~sign-in/stanfordLogo.png.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/src/routes/~sign-in/~index.tsx
+++ b/src/routes/~sign-in/~index.tsx
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/testSetup.ts
+++ b/src/testSetup.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/utils/head.ts
+++ b/src/utils/head.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/utils/useNavigateOrOpen/index.ts
+++ b/src/utils/useNavigateOrOpen/index.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/utils/useNavigateOrOpen/useNavigateOrOpen.ts
+++ b/src/utils/useNavigateOrOpen/useNavigateOrOpen.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/src/vite-envs.d.ts
+++ b/src/vite-envs.d.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+# This source file is part of the ENGAGE-HF Web Frontend open-source project
 #
 # SPDX-FileCopyrightText: 2023 Stanford University
 #

--- a/tsconfig.json.license
+++ b/tsconfig.json.license
@@ -1,5 +1,5 @@
 
-This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+This source file is part of the ENGAGE-HF Web Frontend open-source project
 
 SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 //
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
@@ -25,7 +25,7 @@ export default defineConfig({
       generatedRouteTree: "./src/routeTree.gen.ts",
       routeTreeFileHeader: [
         `//
-// This source file is part of the Stanford Biodesign Digital Health ENGAGE-HF open-source project
+// This source file is part of the ENGAGE-HF Web Frontend open-source project
 //
 // SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //


### PR DESCRIPTION
### :recycle: Current situation & Problem

`SchmiedmayerLab/.github` defines the organization repository standard in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md) and enforces it in `repository-standards.yml`. This repository does not call that workflow yet.

No related issue was identified.

### :gear: Release Notes

- Call `repository-standards.yml@v0.5` from a new `.github/workflows/repository-standards.yml`.
- Pin every shared workflow reference to `v0.5`.
- Complete `CITATION.cff` with the fields Zenodo reads, and bring `CONTRIBUTORS.md` to the documented shape.
- Add the badge block and the Contributing, License, Citation and Our Research sections to the README.
- Group Dependabot updates into a single weekly pull request.
- Name the same project in every SPDX header.

### :books: Documentation

The standard is documented in [`REPOSITORY_STANDARDS.md`](https://github.com/SchmiedmayerLab/.github/blob/main/REPOSITORY_STANDARDS.md).

### :white_check_mark: Testing

- `actionlint`, `yamllint` and `reuse lint`
- `repository-standards.yml@v0.5` runs on this pull request

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).