### PR TITLE
Run the Shared Standard Checks Once

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,15 +18,6 @@ on:
   workflow_call:
 
 jobs:
-  reuseaction:
-    name: REUSE Compliance Check
-    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.5
-  markdownlinkcheck:
-    name: Markdown Link Check
-    permissions:
-      contents: read
-      pull-requests: read
-    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.5
   eslint:
     name: ESLint
     uses: SchmiedmayerLab/.github/.github/workflows/eslint.yml@v0.5


### PR DESCRIPTION
### :recycle: Current situation & Problem

The organization standards workflow already runs the shared REUSE, markdown link and actionlint checks, and this repository calls the same reusable workflows a second time. Every pull request therefore runs each of them twice and reports two checks for the same work, which doubles the cost and lets a transient failure in one copy contradict the other.

No related issue was identified.

### :gear: Release Notes

- Run the shared standard checks once, through the organization standards workflow, and drop this repository's second copy.

### :books: Documentation

No documentation changes are required.

### :white_check_mark: Testing

- `actionlint`
- The checks the organization standards workflow reports are unchanged and remain required to merge

### Code of Conduct & Contributing Guidelines

By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
